### PR TITLE
add parser as subtree

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ serde_derive = "1.0.79"
 serde_json = "1.0.27"
 colored = "1.6"
 pbr = "1.0.1"
-socool_parser = { path = "../socool_parser" }
+socool_parser = { path = "parser" }
 clap = "2.32.0"
 itertools = "0.7.8"
 num-rational = "0.2"

--- a/parser/.gitignore
+++ b/parser/.gitignore
@@ -1,0 +1,2 @@
+/target
+**/*.rs.bk

--- a/parser/Cargo.lock
+++ b/parser/Cargo.lock
@@ -1,0 +1,669 @@
+[[package]]
+name = "aho-corasick"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "memchr 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "arrayref"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "ascii-canvas"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "term 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "atty"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "bit-set"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bit-vec 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "bitflags"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "block-buffer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "arrayref 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byte-tools 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "byte-tools"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "cfg-if"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "cloudabi"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "colored"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "diff"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "digest"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "generic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "docopt"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.79 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.79 (registry+https://github.com/rust-lang/crates.io-index)",
+ "strsim 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "either"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "ena"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "fake-simd"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "fixedbitset"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "fuchsia-zircon"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "fuchsia-zircon-sys"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "generic-array"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "itertools"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "either 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "kernel32-sys"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "lalrpop"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "ascii-canvas 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bit-set 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "diff 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "digest 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "docopt 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ena 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lalrpop-snap 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lalrpop-util 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "petgraph 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.79 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.79 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha2 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "term 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "lalrpop-snap"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "ascii-canvas 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bit-set 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "diff 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ena 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lalrpop-util 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "petgraph 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "term 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "lalrpop-util"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "lazy_static"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "log"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "memchr"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "new_debug_unreachable"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "ordermap"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "petgraph"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "fixedbitset 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ordermap 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.7.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "phf_shared 0.7.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.7.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "siphasher 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "precomputed-hash"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "proc-macro2"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "0.4.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "quote"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "quote"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand_core 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "redox_syscall"
+version = "0.1.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "redox_termios"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "regex"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "aho-corasick 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "utf8-ranges 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "regex"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "aho-corasick 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "utf8-ranges 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "regex-syntax"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "ucd-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "ucd-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "serde_derive"
+version = "1.0.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "sha2"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "block-buffer 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byte-tools 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "digest 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "siphasher"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "socool_parser"
+version = "0.1.0"
+dependencies = [
+ "colored 1.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lalrpop 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lalrpop-util 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "string_cache"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "new_debug_unreachable 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "phf_shared 0.7.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "precomputed-hash 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.79 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache_codegen 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache_shared 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "string_cache_codegen"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "phf_generator 0.7.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "phf_shared 0.7.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache_shared 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "string_cache_shared"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "strsim"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "syn"
+version = "0.15.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "term"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "termion"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "thread_local"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "typenum"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "ucd-util"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "unicode-xid"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "unreachable"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "utf8-ranges"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "version_check"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "void"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "winapi-build"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[metadata]
+"checksum aho-corasick 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)" = "68f56c7353e5a9547cbd76ed90f7bb5ffc3ba09d4ea9bd1d8c06c8b1142eeb5a"
+"checksum arrayref 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0d382e583f07208808f6b1249e60848879ba3543f57c32277bf52d69c2f0f0ee"
+"checksum ascii-canvas 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b385d69402821a1c254533a011a312531cbcc0e3e24f19bbb4747a5a2daf37e2"
+"checksum atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9a7d5b8723950951411ee34d271d99dddcc2035a16ab25310ea2c8cfd4369652"
+"checksum bit-set 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6f1efcc46c18245a69c38fcc5cc650f16d3a59d034f3106e9ed63748f695730a"
+"checksum bit-vec 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4440d5cb623bb7390ae27fec0bb6c61111969860f8e3ae198bfa0663645e67cf"
+"checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
+"checksum block-buffer 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a076c298b9ecdb530ed9d967e74a6027d6a7478924520acddcddc24c1c8ab3ab"
+"checksum byte-tools 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "560c32574a12a89ecd91f5e742165893f86e3ab98d21f8ea548658eb9eef5f40"
+"checksum cfg-if 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0c4e7bb64a8ebb0d856483e1e682ea3422f883c5f5615a90d51a2c82fe87fdd3"
+"checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
+"checksum colored 1.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dc0a60679001b62fb628c4da80e574b9645ab4646056d7c9018885efffe45533"
+"checksum diff 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "3c2b69f912779fbb121ceb775d74d51e915af17aaebc38d28a592843a2dd0a3a"
+"checksum digest 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "03b072242a8cbaf9c145665af9d250c59af3b958f83ed6824e13533cf76d5b90"
+"checksum docopt 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d8acd393692c503b168471874953a2531df0e9ab77d0b6bbc582395743300a4a"
+"checksum either 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3be565ca5c557d7f59e7cfcf1844f9e3033650c929c6566f511e8005f205c1d0"
+"checksum ena 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "88dc8393b3c7352f94092497f6b52019643e493b6b890eb417cdb7c46117e621"
+"checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
+"checksum fixedbitset 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "86d4de0081402f5e88cdac65c8dcdcc73118c1a7a465e2a05f0da05843a8ea33"
+"checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
+"checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
+"checksum generic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ef25c5683767570c2bbd7deba372926a55eaae9982d7726ee2a1050239d45b9d"
+"checksum itertools 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)" = "f58856976b776fedd95533137617a02fb25719f40e7d9b01c7043cd65474f450"
+"checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
+"checksum lalrpop 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9f7014afd5642680074fd5dcc624d544f9eabfa281cba2c3ac56c3db6d21ad1b"
+"checksum lalrpop-snap 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0b85aa455529344133d7ecaaac04c01ed87f459deeaa0fe5422885e2095d8cdc"
+"checksum lalrpop-util 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2400aeebcd11259370d038c24821b93218dd2f33a53f53e9c8fcccca70be6696"
+"checksum lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ca488b89a5657b0a2ecd45b95609b3e848cf1755da332a0da46e2b2b1cb371a7"
+"checksum libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)" = "76e3a3ef172f1a0b9a9ff0dd1491ae5e6c948b94479a3021819ba7d860c8645d"
+"checksum log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "d4fcce5fa49cc693c312001daf1d13411c4a5283796bac1084299ea3e567113f"
+"checksum memchr 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4b3629fe9fdbff6daa6c33b90f7c08355c1aca05a3d01fa8063b822fcf185f3b"
+"checksum new_debug_unreachable 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0cdc457076c78ab54d5e0d6fa7c47981757f1e34dc39ff92787f217dede586c4"
+"checksum ordermap 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "a86ed3f5f244b372d6b1a00b72ef7f8876d0bc6a78a4c9985c53614041512063"
+"checksum petgraph 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)" = "9c3659d1ee90221741f65dd128d9998311b0e40c5d3c23a62445938214abce4f"
+"checksum phf_generator 0.7.23 (registry+https://github.com/rust-lang/crates.io-index)" = "03dc191feb9b08b0dc1330d6549b795b9d81aec19efe6b4a45aec8d4caee0c4b"
+"checksum phf_shared 0.7.23 (registry+https://github.com/rust-lang/crates.io-index)" = "b539898d22d4273ded07f64a05737649dc69095d92cb87c7097ec68e3f150b93"
+"checksum precomputed-hash 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
+"checksum proc-macro2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "1b06e2f335f48d24442b35a19df506a835fb3547bc3c06ef27340da9acf5cae7"
+"checksum proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)" = "3d7b7eaaa90b4a90a932a9ea6666c95a389e424eff347f0f793979289429feee"
+"checksum quote 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9949cfe66888ffe1d53e6ec9d9f3b70714083854be20fd5e271b232a017401e8"
+"checksum quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)" = "dd636425967c33af890042c483632d33fa7a18f19ad1d7ea72e8998c6ef8dea5"
+"checksum rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e464cd887e869cddcae8792a4ee31d23c7edd516700695608f5b98c67ee0131c"
+"checksum rand_core 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1961a422c4d189dfb50ffa9320bf1f2a9bd54ecb92792fb9477f99a1045f3372"
+"checksum rand_core 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0905b6b7079ec73b314d4c748701f6931eb79fd97c668caa3f1899b22b32c6db"
+"checksum redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "c214e91d3ecf43e9a4e41e578973adeb14b474f2bee858742d127af75a0112b1"
+"checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
+"checksum regex 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9329abc99e39129fcceabd24cf5d85b4671ef7c29c50e972bc5afe32438ec384"
+"checksum regex 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "2069749032ea3ec200ca51e4a31df41759190a88edca0d2d86ee8bedf7073341"
+"checksum regex-syntax 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "8e931c58b93d86f080c734bfd2bce7dd0079ae2331235818133c8be7f422e20e"
+"checksum regex-syntax 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7d707a4fa2637f2dca2ef9fd02225ec7661fe01a53623c1e6515b6916511f7a7"
+"checksum regex-syntax 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "747ba3b235651f6e2f67dfa8bcdcd073ddb7c243cb21c442fc12395dfcac212d"
+"checksum serde 1.0.79 (registry+https://github.com/rust-lang/crates.io-index)" = "84257ccd054dc351472528c8587b4de2dbf0dc0fe2e634030c1a90bfdacebaa9"
+"checksum serde_derive 1.0.79 (registry+https://github.com/rust-lang/crates.io-index)" = "31569d901045afbff7a9479f793177fe9259819aff10ab4f89ef69bbc5f567fe"
+"checksum sha2 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9eb6be24e4c23a84d7184280d2722f7f2731fcdd4a9d886efbfe4413e4847ea0"
+"checksum siphasher 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0b8de496cf83d4ed58b6be86c3a275b8602f6ffe98d3024a869e124147a9a3ac"
+"checksum string_cache 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "25d70109977172b127fe834e5449e5ab1740b9ba49fa18a2020f509174f25423"
+"checksum string_cache_codegen 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "35293b05cf1494e8ddd042a7df6756bf18d07f42d234f32e71dce8a7aabb0191"
+"checksum string_cache_shared 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b1884d1bc09741d466d9b14e6d37ac89d6909cbcac41dd9ae982d4d063bbedfc"
+"checksum strsim 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b4d15c810519a91cf877e7e36e63fe068815c678181439f2f29e2562147c3694"
+"checksum syn 0.15.8 (registry+https://github.com/rust-lang/crates.io-index)" = "356d1c5043597c40489e9af2d2498c7fefc33e99b7d75b43be336c8a59b3e45e"
+"checksum term 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "fa63644f74ce96fbeb9b794f66aff2a52d601cbd5e80f4b97123e3899f4570f1"
+"checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
+"checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
+"checksum typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "612d636f949607bdf9b123b4a6f6d966dedf3ff669f7f045890d3a4a73948169"
+"checksum ucd-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fd2be2d6639d0f8fe6cdda291ad456e23629558d466e2789d2c3e9892bda285d"
+"checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
+"checksum unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
+"checksum utf8-ranges 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fd70f467df6810094968e2fce0ee1bd0e87157aceb026a8c083bcf5e25b9efe4"
+"checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
+"checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+"checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
+"checksum winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "92c1eb33641e276cfa214a0522acad57be5c56b10cb348b3c5117db75f3ac4b0"
+"checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
+"checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+"checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "socool_parser"
+version = "0.1.0"
+authors = ["Danny Meyer <Danny.Meyer@gmail.com>"]
+edition = "2018"
+build = "build.rs" # LALRPOP preprocessing
+
+[build-dependencies]
+lalrpop = "0.16.0"
+
+[dependencies]
+lalrpop-util = "0.16.0"
+regex = "0.2.1"
+colored = "1.6"

--- a/parser/README.md
+++ b/parser/README.md
@@ -1,0 +1,1 @@
+# weresocool-parser

--- a/parser/build.rs
+++ b/parser/build.rs
@@ -1,0 +1,5 @@
+extern crate lalrpop;
+
+fn main() {
+    lalrpop::Configuration::new().process_current_dir().unwrap();
+}

--- a/parser/lang.socool
+++ b/parser/lang.socool
@@ -1,0 +1,126 @@
+def init { f: 200, l: 1.0, g: 1.0, p: 0.0 }
+
+{ f: 200, l: 1.0, g: 1.0, p: 0.0 }
+
+let thing = {
+    Sequence [
+     Tm 3/2
+
+    ]
+}
+let thing2 = {
+    Tm 5/4
+    | Repeat 5
+    > fitLength thing
+}
+let main = {
+    Overlay [
+        Sequence[
+            thing,
+            thing2
+        ]
+        > fitLength thing
+    ]
+}
+
+let test = Overlay [
+
+
+      thing3
+    | Repeat 3
+    | Tm 2.0
+    > fitLength (thing2 | thing2)
+
+    ~~>>
+
+    op1 > fit(op2)
+
+    ~~>>
+
+    op1 | withLROf(top: op2, bottom: op1)
+
+
+    op1 | withLROf(top: op2, bottom: op3)
+
+
+
+    op1
+    > op2
+    > op3
+
+
+    ~~>
+
+    (op1 > op2) > op3
+
+
+    (op1 | withLROf(op2 / op1)) | withLrOf(op3 / (op1 | withLROf(op2 / op1)))
+
+
+
+    op1 > (op2 > op3)
+
+    ,
+
+    thing2
+
+]
+
+let thing1 = sequence[
+    AsIs,
+    Tm 7/8,
+    Tm 5/4,
+    Tm 15/8
+    | Gain 0.5
+    | Length 0.5,
+    Tm 5/4,
+];
+
+let thing2 = sequence[
+    AsIs,
+    Tm 9/8,
+    Tm 5/4
+    | Length 0.5
+    Tm 3/2,
+];
+
+shortthing =
+    AsIs,
+    Tm 2.0
+
+let thing3 = Sequence [
+    thing1,
+    | thing2
+    | shortthing;
+]
+
+let main = Overlay [
+    thing3
+    | Length 0.5
+    | withLengthOf(thing1)
+    | Tm 2.0,
+
+    thing1
+]
+
+let main =
+    Sequence [
+        Overlay [
+            o[(3/2, 3.0, 1.0, 0.0),
+              (3/2, 0.0, 1.0, 0.0),
+              (1, 0.0, 1.0, 0.0)]
+            | thing2
+            | Sequence [ AsIs, AsIs ]
+            | WithLengthOf(
+                AsIs
+                | Repeat 2
+            ),
+
+            thing1
+        ]
+        | Repeat 4,
+
+        thing1
+    ]
+    ;
+

--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -1,0 +1,42 @@
+#[derive(Clone, PartialEq, Debug)]
+pub enum Op {
+    AsIs,
+    Reverse,
+    Silence {
+        m: f32,
+    },
+    TransposeM {
+        m: f32,
+    },
+    TransposeA {
+        a: f32,
+    },
+    PanM {
+        m: f32,
+    },
+    PanA {
+        a: f32,
+    },
+    Gain {
+        m: f32,
+    },
+    Length {
+        m: f32,
+    },
+
+    Sequence {
+        operations: Vec<Op>,
+    },
+    Overlay {
+        operations: Vec<Op>,
+    },
+    Compose {
+        operations: Vec<Op>,
+    },
+
+    WithLengthRatioOf {
+        with_length_of: Box<Op>,
+        main: Box<Op>,
+    },
+}
+

--- a/parser/src/comment_stripper.rs
+++ b/parser/src/comment_stripper.rs
@@ -1,0 +1,22 @@
+extern crate weresocool;
+use std::io::BufReader;
+use std::io::BufRead;
+use std::fs::File;
+
+fn main() {
+    let f = File::open("songs/template.socool").unwrap();
+    let file = BufReader::new(&f);
+    let mut composition = String::new();
+    for (num, line) in file.lines().enumerate() {
+        let l = line.unwrap();
+        let copy_l = l.trim_left();
+        if copy_l.starts_with("--") {
+            composition.push_str("\n".to_string);
+        } else {
+            composition.push_str(l);
+        }
+    }
+
+    write!(composition);
+}
+

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -1,0 +1,4 @@
+#[macro_use]
+extern crate lalrpop_util;
+pub mod ast;
+pub mod parser;

--- a/parser/src/main.rs
+++ b/parser/src/main.rs
@@ -1,0 +1,29 @@
+extern crate colored;
+extern crate socool_parser;
+use colored::*;
+use socool_parser::parser::*;
+use std::env;
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    let filename;
+    if args.len() == 2 {
+        filename = &args[1];
+    } else {
+        println!("\n{}\n", "Forgot to pass in a filename.".red().bold());
+        println!("{}", "Example:".cyan());
+        println!("{}\n", "./weresocool song.socool".cyan().italic());
+        panic!("Wrong number of arguments.")
+    }
+
+    let parsed = parse_file(filename);
+
+    for (key, val) in parsed.table.iter() {
+        println!("\n Name: {:?} op: {:?}", key, val);
+    }
+
+    println!("\n Main: {:?}", parsed.table.get("main").unwrap());
+}
+
+#[cfg(test)]
+mod test;

--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -1,0 +1,100 @@
+lalrpop_mod!(pub socool);
+extern crate colored;
+use colored::*;
+use std::fs::File;
+use std::io::prelude::*;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::cmp;
+use std::io::BufReader;
+use crate::ast::*;
+
+#[derive(Clone, PartialEq, Debug)]
+pub struct Init {
+    pub f: f32,
+    pub l: f32,
+    pub g: f32,
+    pub p: f32,
+}
+
+pub type ParseTable = HashMap<String, Op>;
+
+#[derive(Clone, PartialEq, Debug)]
+pub struct ParsedComposition {
+    pub init: Init,
+    pub table: ParseTable,
+}
+
+pub fn parse_file(filename: &String) -> ParsedComposition {
+    let mut table = HashMap::new();
+    let f = File::open(filename);
+    let mut composition = String::new();
+
+    match f {
+        Ok(f) => {
+            let file = BufReader::new(&f);
+            for line in file.lines() {
+                let l = line.unwrap();
+                let copy_l = l.trim_left();
+                if copy_l.starts_with("--") {
+                    composition.push_str("\n");
+                } else {
+                    composition.push_str("\n");
+                    composition.push_str(&l);
+                }
+            }
+        },
+        _ => {
+            println!("{} {}\n", "\n        File not found:".red().bold(), filename.red().bold());
+            panic!("File not found");
+        }
+    }
+
+    let init = socool::SoCoolParser::new()
+        .parse(&mut table, &composition);
+
+    match init.clone() {
+        Ok(init) => ParsedComposition { init, table },
+        Err(error) => {
+            let start_offset = 150;
+            let end_offset = 50;
+            let location = Arc::new(Mutex::new(Vec::new()));
+            error.map_location(|l| location.lock().unwrap().push(l));
+            let start = location.lock().unwrap()[0];
+            let end =  location.lock().unwrap()[1];
+            let cmp_len = &composition.len();
+            let feed_start = cmp::max(0, start as isize - start_offset) as usize;
+            let feed_end = cmp::min(end + end_offset, *cmp_len);
+
+            let mut lines = 1;
+            let mut n_c = 0;
+            for c in composition.clone().chars() {
+                n_c += 1;
+                if n_c > start { break; }
+
+                if c == '\n' {
+                    lines += 1
+                }
+            }
+            println!("{}{}",
+                &composition[feed_start..start].yellow(),
+                &composition[start..feed_end].red(),
+            );
+
+
+            println!("
+            {}
+            errors at line {}
+            {}
+            ",
+             "working".yellow().underline(),
+             lines.to_string().red().bold(),
+             "broken".red().underline(),
+            );
+
+            panic!("Unexpected Token")
+        }
+    }
+}
+
+

--- a/parser/src/socool.lalrpop
+++ b/parser/src/socool.lalrpop
@@ -1,0 +1,121 @@
+use std::str::FromStr;
+use std::string::String;
+use crate::ast::Op;
+use crate::parser::Init;
+use std::collections::HashMap;
+
+grammar<'table>(table: &'table mut HashMap<String, Op>);
+
+pub SoCool: Init = {
+  <init: Point> <l: LetDefs> => { init },
+}
+
+Point: Init = {
+    "{"
+         "f:" <f:Rational> ","
+         "l:" <l:Rational> ","
+         "g:" <g:Rational> ","
+         "p:" <p:Rational>
+    "}" ";"? => Init { f, l, g, p }
+}
+
+LetDefs = Lets<LetDef>;
+LetDef: () = {
+    <s: Name> "=" "{" <o: Operation> "}" => { table.insert(s.clone(), o); () },
+}
+
+Operation: Op = {
+    <op1: ComposeOperation> ">" "FitLength" <op2: ComposeOperation> => Op::Compose { operations: vec![op1.clone(), Op::WithLengthRatioOf { with_length_of: Box::new(op2), main: Box::new(op1) }] },
+    <op: ComposeOperation> => op
+}
+
+ComposeOperation: Op = {
+    <ops: Pipe<BaseOperation>> => Op::Compose { operations: ops },
+    <o: BaseOperation> => o,
+}
+
+BaseOperation: Op = {
+    "(" <o: Operation> ")" => o,
+    "AsIs" => Op::AsIs {},
+    "Reverse" => Op::Reverse {},
+    "Repeat" <i:Int> => {
+        let mut vec = Vec::new();
+        for x in 0..i {
+            vec.push(Op::AsIs)
+        }
+        Op::Sequence { operations: vec }
+    },
+    "Silence" <v:Rational> => Op::Silence {m: v},
+    "Tm" <v:Rational> => Op::TransposeM {m: v},
+    "Ta" <v:Rational> => Op::TransposeA {a: v},
+    "PanM" <v:Rational> => Op::PanM {m: v},
+    "PanA" <v:Rational> => Op::PanA {a: v},
+    "Length" <v:Rational> => Op::Length {m: v},
+    "Gain" <v:Rational> => Op::Gain {m: v},
+    "Sequence" "[" <operations: Operations> "]" => Op::Sequence { operations: operations },
+    "Overlay" "[" <operations: Operations> "]" => Op::Overlay { operations: operations },
+    "O" "[" <o: Overtones> "]" => Op::Overlay { operations: o },
+    <id: Name> => { table.get(&id).unwrap().clone() },
+};
+
+Overtone: Op = {
+    "("
+        <v:Rational> ","
+        <o:Rational> ","
+        <g:Rational> ","
+        <p:Rational>
+    ")"
+    => Op::Compose { operations: vec! [
+            Op::TransposeM { m: v },
+            Op::TransposeA { a: o },
+            Op::Gain { m: g },
+            Op::PanA { a: p },
+        ]
+    }
+}
+
+Overtones = Comma<Overtone>;
+
+Comma<T>: Vec<T> = {
+    <v:(<T> ",")*> <e:T?> => match e {
+        None=> v,
+        Some(e) => {
+            let mut v = v;
+            v.push(e);
+            v
+        }
+    }
+};
+
+Lets<T>: Vec<T> = {
+  <v:(<T>)*> => v
+};
+
+Pipe<T>: Vec<T> = {
+    <v:(<T> "|")+> <e:T?> => match e {
+        None=> v,
+        Some(e) => {
+          let mut v = v;
+          v.push(e);
+          v
+        }
+    }
+};
+
+Compose = Pipe<Operation>;
+
+Operations = Comma<Operation>;
+
+Num: f32 = {
+   <n: Float> => n,
+   <n: Int> => { n as f32 }
+}
+
+Rational: f32 = {
+    <n:Num> => n,
+    <n:Num> "/" <d:Num> => n/d,
+};
+
+Name: String = <s:r"[a-z_$][a-zA-Z_$0-9]*"> => s.to_string();
+Float: f32 = <s:r"-?(0|([1-9]\d*))\.\d+"> => f32::from_str(s).unwrap();
+Int: i32 = <s:r"-?[0-9]+"> => i32::from_str(s).unwrap();

--- a/parser/src/test.rs
+++ b/parser/src/test.rs
@@ -1,0 +1,294 @@
+pub mod test {
+    use socool_parser::ast::{Op};
+    use socool_parser::parser::*;
+    use std::collections::HashMap;
+
+    fn mock_init() -> (String) {
+        "{ f: 200, l: 1.0, g: 1.0, p: 0.0 }
+            main = {"
+            .to_string()
+    }
+
+    fn test_parsed_operation(mut parse_str: String, expected: Op) {
+        let mut table = HashMap::new();
+
+        parse_str.push_str("}");
+
+        let _result = socool::SoCoolParser::new().parse(&mut table, &parse_str);
+
+        let main = table.get(&"main".to_string()).unwrap();
+        assert_eq!(*main, expected);
+    }
+
+    #[test]
+    fn init_test() {
+        let mut parse_str = mock_init();
+        let mut table = HashMap::new();
+        parse_str.push_str("AsIs }");
+        let init = socool::SoCoolParser::new()
+            .parse(&mut table, &parse_str)
+            .unwrap();
+        assert_eq!(
+            init,
+            Init {
+                f: 200.0,
+                l: 1.0,
+                g: 1.0,
+                p: 0.0
+            }
+        );
+    }
+
+    #[test]
+    fn tm_test() {
+        let mut parse_str = mock_init();
+        parse_str.push_str("Tm 3/2");
+        test_parsed_operation(parse_str, Op::TransposeM { m: 1.5 });
+    }
+
+    #[test]
+    fn ta_test() {
+        let mut parse_str = mock_init();
+        parse_str.push_str("Ta 2.0");
+        test_parsed_operation(parse_str, Op::TransposeA { a: 2.0 });
+    }
+
+    #[test]
+    fn pan_a_test() {
+        let mut parse_str = mock_init();
+        parse_str.push_str("PanA 2.0");
+        test_parsed_operation(parse_str, Op::PanA { a: 2.0 });
+    }
+
+    #[test]
+    fn pan_m_test() {
+        let mut parse_str = mock_init();
+        parse_str.push_str("PanM 3.0/2.0");
+        test_parsed_operation(parse_str, Op::PanM { m: 1.5 });
+    }
+
+    #[test]
+    fn gain_test() {
+        let mut parse_str = mock_init();
+        parse_str.push_str("Gain 0.25");
+        test_parsed_operation(parse_str, Op::Gain { m: 0.25 });
+    }
+
+    #[test]
+    fn length_test() {
+        let mut parse_str = mock_init();
+        parse_str.push_str("Length 0.5");
+        test_parsed_operation(parse_str, Op::Length { m: 0.5 });
+    }
+
+    #[test]
+    fn reverse_test() {
+        let mut parse_str = mock_init();
+        parse_str.push_str("Reverse");
+        test_parsed_operation(parse_str, Op::Reverse);
+    }
+
+    #[test]
+    fn asis_test() {
+        let mut parse_str = mock_init();
+        parse_str.push_str("AsIs");
+        test_parsed_operation(parse_str, Op::AsIs);
+    }
+
+    #[test]
+    fn sequence_test() {
+        let mut parse_str = mock_init();
+        parse_str.push_str(
+            "
+                Sequence [
+                    AsIs,
+                    Tm 3/2,
+                ]
+            ",
+        );
+        test_parsed_operation(
+            parse_str,
+            Op::Sequence {
+                operations: vec![Op::AsIs, Op::TransposeM { m: 3.0 / 2.0 }],
+            },
+        );
+    }
+
+    #[test]
+    fn overlay_test() {
+        let mut parse_str = mock_init();
+        parse_str.push_str(
+            "
+                Overlay [
+                    AsIs,
+                    Tm 3/2,
+                ]
+            ",
+        );
+        test_parsed_operation(
+            parse_str,
+            Op::Overlay {
+                operations: vec![Op::AsIs, Op::TransposeM { m: 3.0 / 2.0 }],
+            },
+        );
+    }
+
+    #[test]
+    fn o_test() {
+        let mut parse_str = mock_init();
+        parse_str.push_str(
+            "
+                O[(3/2, 3.0, 1.0, 0.3),
+                  (1, 0.0, 0.5, 0.0)]
+            ",
+        );
+        test_parsed_operation(
+            parse_str,
+            Op::Overlay {
+                operations: vec![
+                    Op::Compose {
+                        operations: vec![
+                            Op::TransposeM { m: 1.5 },
+                            Op::TransposeA { a: 3.0 },
+                            Op::Gain { m: 1.0 },
+                            Op::PanA { a: 0.3 },
+                        ],
+                    },
+                    Op::Compose {
+                        operations: vec![
+                            Op::TransposeM { m: 1.0 },
+                            Op::TransposeA { a: 0.0 },
+                            Op::Gain { m: 0.5 },
+                            Op::PanA { a: 0.0 },
+                        ],
+                    },
+                ],
+            },
+        );
+    }
+
+    #[test]
+    fn let_insert() {
+        let mut table = HashMap::new();
+        socool::SoCoolParser::new()
+            .parse(
+                &mut table,
+                "
+                    { f: 200, l: 1.0, g: 1.0, p: 0.0 }
+
+                    thing = {
+                        Tm 3/2
+                        | Gain 0.3
+                    }
+                    ",
+            )
+            .unwrap();
+        let thing = table.get(&"thing".to_string()).unwrap();
+        assert_eq!(
+            *thing,
+            Op::Compose {
+                operations: vec![Op::TransposeM { m: 1.5 }, Op::Gain { m: 0.3 }]
+            }
+        )
+    }
+
+    #[test]
+    fn let_get() {
+        let mut table = HashMap::new();
+        socool::SoCoolParser::new()
+            .parse(
+                &mut table,
+                "
+                    { f: 200, l: 1.0, g: 1.0, p: 0.0 }
+
+                    thing = {
+                        Tm 3/2
+                        | Gain 0.3
+                    }
+
+                    main = { thing }
+                    ",
+            )
+            .unwrap();
+    }
+
+    #[test]
+    fn fit_length_test() {
+        let mut table = HashMap::new();
+
+        let _result = socool::SoCoolParser::new().parse(
+            &mut table,
+            "
+                { f: 200, l: 1.0, g: 1.0, p: 0.0 }
+
+                thing = {
+                    Sequence [
+                     AsIs,
+                     Tm 3/2
+                     | Length 2.0
+                    ]
+                }
+
+                thing2 = {
+                    Sequence [
+                        Tm 5/4,
+                        Tm 3/2
+                    ]
+                    | Repeat 2
+                    > FitLength thing
+                }
+
+                main = {
+                    thing2
+                }
+            ",
+        );
+        let thing = table.get(&"main".to_string()).unwrap();
+        assert_eq!(
+            *thing,
+            Op::Compose {
+                operations: vec![
+                    Op::Compose {
+                        operations: vec![
+                            Op::Sequence {
+                                operations: vec![
+                                    Op::TransposeM { m: 1.25 },
+                                    Op::TransposeM { m: 1.5 }
+                                ]
+                            },
+                            Op::Sequence {
+                                operations: vec![Op::AsIs, Op::AsIs]
+                            }
+                        ]
+                    },
+                    Op::WithLengthRatioOf {
+                        with_length_of: Box::new(Op::Sequence {
+                            operations: vec![
+                                Op::AsIs,
+                                Op::Compose {
+                                    operations: vec![
+                                        Op::TransposeM { m: 1.5 },
+                                        Op::Length { m: 2.0 }
+                                    ]
+                                }
+                            ]
+                        }),
+                        main: Box::new(Op::Compose {
+                            operations: vec![
+                                Op::Sequence {
+                                    operations: vec![
+                                        Op::TransposeM { m: 1.25 },
+                                        Op::TransposeM { m: 1.5 }
+                                    ]
+                                },
+                                Op::Sequence {
+                                    operations: vec![Op::AsIs, Op::AsIs]
+                                }
+                            ]
+                        })
+                    }
+                ]
+            }
+        )
+    }
+}

--- a/parser/working.socool
+++ b/parser/working.socool
@@ -1,0 +1,30 @@
+{ f: 200, l: 1.0, g: 1.0, p: 0.0 }
+
+overtones = {
+    O[(3/2, 3.0, 1.0, 0.0),
+      (3/2, 0.0, 1.0, 0.0),
+      (1, 0.0, 1.0, 0.0)]
+}
+
+thing1 = {
+    overtones |
+    Sequence [
+        AsIs,
+        Tm 3/2 | Length 2.0
+    ]
+}
+
+thing2 = {
+    Sequence [
+        Tm 7/4,
+        Tm 3/2
+    ] | Repeat 2
+    > FitLength thing1
+}
+
+main = {
+    Overlay [
+        thing1,
+        thing2
+    ]
+}


### PR DESCRIPTION
This makes the parser a subtree, rather than having it as a separate repository that you have to manually clone.

This was done with `git subtree` so that the git history of the other repository is kept. The "real" commits I did are the two last ones; the rest are the git commits from the other repository. I'd recommend a squash-merge if you do not think there's stuff in the history you will be going back to (the commits will still be in this repository, it's just going to be harder to get to them; and of course, the existing repository won't be affected).
