### PR TITLE
add ModulateBy in makam

### DIFF
--- a/bin/render-via-makam
+++ b/bin/render-via-makam
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 set -e
+set -o pipefail
 
 if [[ $# -lt 1 ]]; then
   echo "Usage: $0 <filename>"

--- a/songs/makam.socool
+++ b/songs/makam.socool
@@ -52,15 +52,21 @@ byh = { bayati_bF }
 byj = { bayati_C }
 byk = { bayati_D }
 
-bayati_melody = { Sequence[ Silence 1, bya, byj, byh, byf, byg, byg, bya, byj, byh, byf, byg, byg, byh, byj, byh, byg, byf, byg, byg, byh, byj, byh, byg, byf, byg, byg, byk, byg, byh, byj, byf, byg, byh, byf, byg, byh, byd, byf, byg, byh, byj, byd, byf, byg, bys, byd, byf, bya, bys, byd, bys, bya, byk, byk, byk, byj, byh, byg, byh, byj, byh, byg, byf, byg, byg, byf, byd, byf, byd, bys, byd, byf, byd, bys, bya ] }
+bayati_melody = { Sequence[ bya, byj, byh, byf, byg, byg, bya ] }
 
-instrument = { Overlay[
-                 AsIs,
-                 byg | Sequence[Silence 0.08, Length 0.01] | Gain 0.4,
-               ] }
+instrument = { Sequence[
+                 Overlay[
+                   AsIs,
+                   Tm 3 | Gain 0.4,
+                 ],
+                 Overlay[
+                   AsIs,
+                   Tm 5 | Gain 0.9,
+                 ]
+              ] }
 
-input = { instrument | bayati_melody }
+input = { instrument > ModulateBy bayati_melody }
 
 main = {
-  input | Length 0.2
+  input | Length 0.2 | Repeat 4
 }

--- a/songs/makam.socool
+++ b/songs/makam.socool
@@ -1,4 +1,6 @@
-{ f: 220, l: 1.0, g: 1.0, p: 0.0}
+-- needs makam!
+
+{ f: 220, l: 0.2, g: 1.0, p: 0.0}
 
 et12semitone = { Tm 1.05946 }
 et12semitonedown = { Tm 0.943878 }
@@ -62,11 +64,21 @@ instrument = { Sequence[
                  Overlay[
                    AsIs,
                    Tm 5 | Gain 0.9,
+                 ],
+                 Overlay[
+                   AsIs,
+                   Tm 2/3 | Gain 0.1,
+                   Tm 4/5 | Gain 0.08,
+                   Tm 6/7 | Gain 0.06,
+                   Tm 10/11 | Gain 0.05,
+                   Tm 12/13 | Gain 0.03,
+                   Tm 16/17 | Gain 0.02,
+                   Tm 22/23 | Gain 0.02
                  ]
               ] }
 
-input = { instrument > ModulateBy bayati_melody }
+input = { (bayati_melody | Repeat 7) > ModulateBy instrument }
 
 main = {
-  input | Length 0.2 | Repeat 4
+  input
 }

--- a/src/makam/ast.makam
+++ b/src/makam/ast.makam
@@ -19,6 +19,7 @@ seq : op -> op -> op.
 compose : op -> op -> op.
 overlay : op -> op -> op.
 let : op -> bindone op op -> op.
+modulate : op -> op -> op.
 
 program : type.
 (* the basic point isn't really optional, but isn't really used anywhere other

--- a/src/makam/syntax.makam
+++ b/src/makam/syntax.makam
@@ -108,7 +108,7 @@ op -> (fun id => fun o1 => fun o2 => let o1 (concrete.bindone (concrete.name var
 op_fit ->
      (fun op1 => fun op2 => fit op1 (fitlength op2))
       { <op_compose> ">" "FitLength" <op_compose> }
-    / (fun op1 => fun op2 => modulate (fit op1 (fitlength op2)) op2)
+    / (fun op1 => fun op2 => modulate op1 (fit op2 (fitlength op1)))
       { <op_compose> ">" "ModulateBy" <op_compose> }
     / op_compose ;
 

--- a/src/makam/syntax.makam
+++ b/src/makam/syntax.makam
@@ -108,6 +108,8 @@ op -> (fun id => fun o1 => fun o2 => let o1 (concrete.bindone (concrete.name var
 op_fit ->
      (fun op1 => fun op2 => fit op1 (fitlength op2))
       { <op_compose> ">" "FitLength" <op_compose> }
+    / (fun op1 => fun op2 => modulate (fit op1 (fitlength op2)) op2)
+      { <op_compose> ">" "ModulateBy" <op_compose> }
     / op_compose ;
 
 op_compose ->

--- a/src/makam/tests.makam
+++ b/src/makam/tests.makam
@@ -37,20 +37,20 @@ output_matches P1 P2 :- fastprint_compiler P1 R1, fastprint_compiler P2 R2, eq R
 >> output_matches {{ Sequence[Overlay[Tm 2, AsIs] | Sequence[AsIs, Tm 5] | Overlay[Tm 3, Tm 4], AsIs] }} {{ Overlay [ Sequence [ Tm 6 , Tm 30 , AsIs ] , Sequence [ Tm 3 , Tm 15 , Silence 1 ] , Sequence [ Tm 8 , Tm 40 , Silence 1 ] , Sequence [ Tm 4 , Tm 20 , Silence 1 ] ] }} ?
 >> Yes.
 
->> output_matches {{ 
+>> output_matches {{
     O[
-    	(5/4, 3.0, 1.0, 1.0),
-      	(9/8, 0.0, 1.0, -1.0),
-      	(1/1, 2.0, 1.0, 0.5),
-      	(1/1, 0.0, 1.0, -0.5),
-  	]
+        (5/4, 3.0, 1.0, 1.0),
+        (9/8, 0.0, 1.0, -1.0),
+        (1/1, 2.0, 1.0, 0.5),
+        (1/1, 0.0, 1.0, -0.5),
+        ]
 }} {{
-  Overlay [ 
-    Sequence [ Tm 5 / 4 | Ta 3 | PanA 1 , ] , 
-    Sequence [ Tm 9 / 8 | PanA -1 , ] , 
-    Sequence [ Ta 2 | PanA 1 / 2 , ] , 
+  Overlay [
+    Sequence [ Tm 5 / 4 | Ta 3 | PanA 1 , ] ,
+    Sequence [ Tm 9 / 8 | PanA -1 , ] ,
+    Sequence [ Ta 2 | PanA 1 / 2 , ] ,
     Sequence [ PanA -1 / 2 , ] ,
-  ] 
+  ]
 }} ?
 >> Yes.
 
@@ -58,7 +58,7 @@ output_matches P1 P2 :- fastprint_compiler P1 R1, fastprint_compiler P2 R2, eq R
 >> Yes:
 >> X := "Overlay [ Sequence [ Tm 3 , Tm 6 ] ] ".
 
->> fastprint_compiler {{ 
+>> fastprint_compiler {{
 
 { f: 220, l: 1.0, g: 1.0, p: 0.0}
 

--- a/src/makam/transforms.makam
+++ b/src/makam/transforms.makam
@@ -50,6 +50,19 @@ combine   (fullpoint_op FM   FA   GM   LM   PM   PA)
   combine_linear PM PA PM' PA' PM'' PA'',
   ratio.mult GM GM' GM'', ratio.mult LM LM' LM''.
 
+modcombine : fullpoint_op -> fullpoint_op -> fullpoint_op -> prop.
+
+modcombine (fullpoint_id) F F.
+modcombine F fullpoint_id F.
+modcombine (fullpoint_sil LR) F' (fullpoint_sil LR).
+modcombine (fullpoint_op _ _ _ LR _ _) (fullpoint_sil _) (fullpoint_sil LR).
+modcombine (fullpoint_op FM   FA   GM   LM   PM   PA)
+           (fullpoint_op FM'  FA'  GM'  _    PM'  PA')
+           (fullpoint_op FM'' FA'' GM'' LM   PM'' PA'') :-
+  combine_linear FM FA FM' FA' FM'' FA'',
+  combine_linear PM PA PM' PA' PM'' PA'',
+  ratio.mult GM GM' GM''.
+
 
 (* lrof: calculate length ratio of an operation *)
 lrof : op -> ratio -> prop.
@@ -65,7 +78,7 @@ lrof (compose O1 O2) Ratio :-
 lrof (let O1 (bind _ O2)) Ratio :-
   lrof O1 Ratio1, (x:op -> lrof x Ratio1 -> lrof (O2 x) Ratio).
 lrof (modulate O1 _) Ratio :-
-  lrof O1 Ratio.
+  lrof O1 Ratio. (* TODO: check that the ratios match *)
 
 (* now for normal programs *)
 
@@ -109,17 +122,16 @@ foreach (sequences S) P Result :-
   map P S Result.
 %end.
 
-transform : normalop -> simpleop -> normalop -> prop.
-transform : voiceop -> simpleop -> voiceop -> prop.
-transform : simpleop -> simpleop -> simpleop -> prop.
-transform : fullpoint_op -> fullpoint_op -> fullpoint_op -> prop.
+transform : (fullpoint_op -> fullpoint_op -> fullpoint_op -> prop) -> normalop -> simpleop -> normalop -> prop.
+transform : (fullpoint_op -> fullpoint_op -> fullpoint_op -> prop) -> voiceop -> simpleop -> voiceop -> prop.
+transform : (fullpoint_op -> fullpoint_op -> fullpoint_op -> prop) -> simpleop -> simpleop -> simpleop -> prop.
 
-transform (overlays O) SOP (overlays O') :- map (pfun V => transform V SOP) O O'.
+transform P (overlays O) SOP (overlays O') :- map (pfun V => transform P V SOP) O O'.
 
-transform (sequences S) SOP (sequences S') :- map (pfun E => transform E SOP) S S'.
+transform P (sequences S) SOP (sequences S') :- map (pfun E => transform P E SOP) S S'.
 
-transform (simpleop Ops) (simpleop Ops') (simpleop Ops'') :-
-  combine Ops Ops' Ops''.
+transform P (simpleop Ops) (simpleop Ops') (simpleop Ops'') :-
+  P Ops Ops' Ops''.
 
 lrof : simpleop -> ratio -> prop.
 lrof (simpleop F) R :- lrof F R.
@@ -149,8 +161,8 @@ chopoff (BeforeCut, (HD :: TL)) LR (BeforeCut', (HD2 :: TL))
   ratio.div (ratio NZ X) LRactual SecondPart,
   point_to_fullpoint_op (lenmult FirstPart) F1,
   point_to_fullpoint_op (lenmult SecondPart) F2,
-  transform HD (simpleop F1) HD1,
-  transform HD (simpleop F2) HD2,
+  transform combine HD (simpleop F1) HD1,
+  transform combine HD (simpleop F2) HD2,
   append BeforeCut [HD1] BeforeCut'.
 
 
@@ -192,21 +204,23 @@ normalize (seq O1 O2) Result :-
 normalize (compose O1 O2) Result :-
   normalize O1 Res1,
   normalize O2 Res2,
-  normalop.foreach Res2 (pfun SimpleOp => transform Res1 SimpleOp) Everything,
+  normalop.foreach Res2 (pfun SimpleOp => transform combine Res1 SimpleOp) Everything,
   map (fold1 normalop.sequence) Everything Everything',
   fold1 normalop.overlay Everything' Result.
 
 normalize (modulate O1 O2) Result :-
   normalize O1 Res1,
-  normalize O2 (overlays [ sequences Seq ]),
+  normalize O2 (overlays Sequences),
   eq Res1 (overlays Voices),
   map (fun u => eq (sequences [])) Voices Voices',
-  foldl (pfun (In, Out) (simpleop F) (In', Out') => [LR Cur Cur']
-    lrof F LR, chopoff In LR Cur In', transform Cur (simpleop F) Cur',
-    normalop.sequence Out Cur' Out')
-  (Res1, (overlays Voices'))
-  Seq
-  (_, Result).
+  map (pfun (sequences Seq) ThisRes => [Unused]
+    foldl (pfun (In, Out) (simpleop F) (In', Out') => [LR Cur Cur']
+      lrof F LR, chopoff In LR Cur In', transform modcombine Cur (simpleop F) Cur',
+      normalop.sequence Out Cur' Out')
+    (Res1, (overlays Voices'))
+    Seq
+    (Unused, ThisRes)) Sequences AllRes,
+  fold1 normalop.overlay AllRes Result.
 
 normalize (let Op1 (bind _ X_Op2)) Result :-
   normalize Op1 Op1', lrof Op1 LR,

--- a/src/makam/transforms.makam
+++ b/src/makam/transforms.makam
@@ -64,6 +64,8 @@ lrof (compose O1 O2) Ratio :-
   lrof O1 Ratio1, lrof O2 Ratio2, ratio.mult Ratio1 Ratio2 Ratio.
 lrof (let O1 (bind _ O2)) Ratio :-
   lrof O1 Ratio1, (x:op -> lrof x Ratio1 -> lrof (O2 x) Ratio).
+lrof (modulate O1 _) Ratio :-
+  lrof O1 Ratio.
 
 (* now for normal programs *)
 
@@ -122,6 +124,34 @@ transform (simpleop Ops) (simpleop Ops') (simpleop Ops'') :-
 lrof : simpleop -> ratio -> prop.
 lrof (simpleop F) R :- lrof F R.
 
+chopoff : normalop -> ratio -> normalop -> normalop -> prop.
+chopoff : voiceop -> ratio -> voiceop -> voiceop -> prop.
+chopoff : (list simpleop * list simpleop) -> ratio -> (list simpleop * list simpleop) -> prop.
+
+chopoff (overlays O) LR (overlays O') (overlays O'') :-
+  map (pfun V => chopoff V LR) O O' O''.
+chopoff (sequences S) LR (sequences S') (sequences S'') :-
+  chopoff ([], S) LR (S', S'').
+
+chopoff (BeforeCut, AfterCut) (ratio 0 _) (BeforeCut, AfterCut).
+
+chopoff (BeforeCut, (HD :: TL)) LR Result
+    when not(eq LR (ratio 0 _)),
+         lrof HD LRactual, ratio.difforzero LRactual LR (ratio 0 X) :-
+  ratio.difforzero LR LRactual LR',
+  append BeforeCut [HD] BeforeCut',
+  chopoff (BeforeCut', TL) LR' Result.
+
+chopoff (BeforeCut, (HD :: TL)) LR (BeforeCut', (HD2 :: TL))
+    when not(eq LR (ratio 0 _)),
+         lrof HD LRactual, ratio.difforzero LRactual LR (ratio NZ X), not(eq NZ 0) :-
+  ratio.div LR LRactual FirstPart,
+  ratio.div (ratio NZ X) LRactual SecondPart,
+  point_to_fullpoint_op (lenmult FirstPart) F1,
+  point_to_fullpoint_op (lenmult SecondPart) F2,
+  transform HD (simpleop F1) HD1,
+  transform HD (simpleop F2) HD2,
+  append BeforeCut [HD1] BeforeCut'.
 
 
 normalize : program -> normalprogram -> prop.
@@ -165,6 +195,18 @@ normalize (compose O1 O2) Result :-
   normalop.foreach Res2 (pfun SimpleOp => transform Res1 SimpleOp) Everything,
   map (fold1 normalop.sequence) Everything Everything',
   fold1 normalop.overlay Everything' Result.
+
+normalize (modulate O1 O2) Result :-
+  normalize O1 Res1,
+  normalize O2 (overlays [ sequences Seq ]),
+  eq Res1 (overlays Voices),
+  map (fun u => eq (sequences [])) Voices Voices',
+  foldl (pfun (In, Out) (simpleop F) (In', Out') => [LR Cur Cur']
+    lrof F LR, chopoff In LR Cur In', transform Cur (simpleop F) Cur',
+    normalop.sequence Out Cur' Out')
+  (Res1, (overlays Voices'))
+  Seq
+  (_, Result).
 
 normalize (let Op1 (bind _ X_Op2)) Result :-
   normalize Op1 Op1', lrof Op1 LR,

--- a/src/makam/transforms.makam
+++ b/src/makam/transforms.makam
@@ -5,8 +5,11 @@ normalprogram : type.
 normalop : type.
 voiceop : type.
 simpleop : type.
-fullpoint_op : type.
 
+(* let's get the tedious part out of the way:
+   fullpoint_op is a combination of multiple unit operations (Tm, Ta, etc.) into one *)
+
+fullpoint_op : type.
 fullpoint_sil : (Silence: ratio) -> fullpoint_op.
 fullpoint_id : fullpoint_op.
 fullpoint_op : (FreqMult: ratio) (FreqAdd: ratio) (GainMult: ratio) (LenMult: ratio) (PanMult: ratio) (PanAdd: ratio) -> fullpoint_op.
@@ -21,17 +24,35 @@ point_to_fullpoint_op (panmult R) (fullpoint_op (ratio 1 1) (ratio 0 1) (ratio 1
 point_to_fullpoint_op (panadd R) (fullpoint_op (ratio 1 1) (ratio 0 1) (ratio 1 1) (ratio 1 1) (ratio 1 1) R).
 point_to_fullpoint_op (silence R) (fullpoint_sil R).
 
-normalprogram : option point -> normalop -> normalprogram.
-overlays  : list voiceop -> normalop.
-sequences : list simpleop -> voiceop.
-simpleop : fullpoint_op -> simpleop.
 
 lrof : fullpoint_op -> ratio -> prop.
-lrof : op -> ratio -> prop.
 
 lrof (fullpoint_id) (ratio 1 1).
 lrof (fullpoint_sil R) R.
 lrof (fullpoint_op _ _ _ LR _ _) LR.
+
+combine_linear : (Mult1: ratio) (Add1: ratio) (Mult2: ratio) (Add2: ratio) (MultR: ratio) (AddR: ratio) -> prop.
+(* (M1 * x + A1) * M2 + A2 = M1 * M2 * x + (A1 * M2 + A2) *)
+combine_linear M1 A1 M2 A2 MR AR :-
+  ratio.mult M1 M2 MR,
+  ratio.mult A1 M2 A1M2, ratio.plus A1M2 A2 AR.
+
+combine : fullpoint_op -> fullpoint_op -> fullpoint_op -> prop.
+
+combine (fullpoint_id) F F.
+combine F fullpoint_id F.
+combine (fullpoint_sil LR) F' (fullpoint_sil LR'') :- lrof F' LR', ratio.mult LR LR' LR''.
+combine (fullpoint_op _ _ _ LR _ _) (fullpoint_sil LR') (fullpoint_sil LR'') :- ratio.mult LR LR' LR''.
+combine   (fullpoint_op FM   FA   GM   LM   PM   PA)
+          (fullpoint_op FM'  FA'  GM'  LM'  PM'  PA')
+          (fullpoint_op FM'' FA'' GM'' LM'' PM'' PA'') :-
+  combine_linear FM FA FM' FA' FM'' FA'',
+  combine_linear PM PA PM' PA' PM'' PA'',
+  ratio.mult GM GM' GM'', ratio.mult LM LM' LM''.
+
+
+(* lrof: calculate length ratio of an operation *)
+lrof : op -> ratio -> prop.
 
 lrof id (ratio 1 1).
 lrof (map F) Ratio :- point_to_fullpoint_op F F', lrof F' Ratio.
@@ -41,6 +62,15 @@ lrof (overlay O1 O2) Ratio :-
   lrof O1 Ratio1, lrof O2 Ratio2, ratio.max Ratio1 Ratio2 Ratio.
 lrof (compose O1 O2) Ratio :-
   lrof O1 Ratio1, lrof O2 Ratio2, ratio.mult Ratio1 Ratio2 Ratio.
+lrof (let O1 (bind _ O2)) Ratio :-
+  lrof O1 Ratio1, (x:op -> lrof x Ratio1 -> lrof (O2 x) Ratio).
+
+(* now for normal programs *)
+
+normalprogram : option point -> normalop -> normalprogram.
+overlays  : list voiceop -> normalop.
+sequences : list simpleop -> voiceop.
+simpleop : fullpoint_op -> simpleop.
 
 fold1 : (A -> A -> A -> prop) -> list A -> A -> prop.
 fold1 P (HD :: TL) Result :-
@@ -87,25 +117,12 @@ transform (overlays O) SOP (overlays O') :- map (pfun V => transform V SOP) O O'
 transform (sequences S) SOP (sequences S') :- map (pfun E => transform E SOP) S S'.
 
 transform (simpleop Ops) (simpleop Ops') (simpleop Ops'') :-
-  transform Ops Ops' Ops''.
+  combine Ops Ops' Ops''.
 
-transform (fullpoint_id) F F.
-transform F fullpoint_id F.
-transform (fullpoint_sil LR) F' (fullpoint_sil LR'') :- lrof F' LR', ratio.mult LR LR' LR''.
-transform (fullpoint_op _ _ _ LR _ _) (fullpoint_sil LR') (fullpoint_sil LR'') :- ratio.mult LR LR' LR''.
+lrof : simpleop -> ratio -> prop.
+lrof (simpleop F) R :- lrof F R.
 
-compose_linear : (Mult1: ratio) (Add1: ratio) (Mult2: ratio) (Add2: ratio) (MultR: ratio) (AddR: ratio) -> prop.
-(* (M1 * x + A1) * M2 + A2 = M1 * M2 * x + (A1 * M2 + A2) *)
-compose_linear M1 A1 M2 A2 MR AR :-
-  ratio.mult M1 M2 MR,
-  ratio.mult A1 M2 A1M2, ratio.plus A1M2 A2 AR.
 
-transform (fullpoint_op FM   FA   GM   LM   PM   PA)
-          (fullpoint_op FM'  FA'  GM'  LM'  PM'  PA')
-          (fullpoint_op FM'' FA'' GM'' LM'' PM'' PA'') :-
-  compose_linear FM FA FM' FA' FM'' FA'',
-  compose_linear PM PA PM' PA' PM'' PA'',
-  ratio.mult GM GM' GM'', ratio.mult LM LM' LM''.
 
 normalize : program -> normalprogram -> prop.
 normalize : op -> normalop -> prop.
@@ -193,6 +210,11 @@ desugar_cases (withlrof Op1 Op2) (map (lenmult Ratio)) :-
   desugar Op1 Op1', desugar Op2 Op2',
   lrof Op1' R1, lrof Op2' R2,
   ratio.div R1 R2 Ratio.
+
+desugar_cases (let Op1 (bind X Op2)) (let Op1' (bind X Op2')) :-
+  desugar Op1 Op1',
+  lrof Op1' LR1,
+  (x:op -> lrof x LR1 -> desugar (Op2 x) (Op2' x)).
 
 desugar_cases (fit Op1 (fitlength Op2)) Result :-
   desugar Op1 Op1', desugar Op2 Op2',


### PR DESCRIPTION
I added a `ModulateBy` thing. What it does is that it basically "modulates" an operation by another one, chopping up the first one at the event boundaries of the second one. The main goal is to do something like `melody > ModulateBy instrument`, where the two things can evolve independently, but where the "voice" changes in `instrument` get applied to the melody as that evolves.

This is probably just an experiment; I wouldn't merge this yet! But if you'd like to try it out, do: `./bin/render-via-makam songs/makam.socool`, and look at the `input` definition on that file.
