### PR TITLE
Stem Generation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.5.0"
 edition = "2018"
 authors = ["Danny Meyer <Danny.Meyer@gmail.com>"]
 description = "***** WereSoCool __!Now In Stereo!__ ****** Make cool sounds. Impress your friends."
-license = "MIT" 
+license = "GPL-3.0" 
 autobins = false
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.5.0"
 edition = "2018"
 authors = ["Danny Meyer <Danny.Meyer@gmail.com>"]
 description = "***** WereSoCool __!Now In Stereo!__ ****** Make cool sounds. Impress your friends."
-license = "MIT"
+license = "MIT" 
 autobins = false
 
 [dependencies]
@@ -53,6 +53,10 @@ members = [
 [[bin]]
 name = "wsc"
 path = "bin/wsc.rs"
+
+[[bin]]
+name = "stems"
+path = "bin/stems.rs"
 
 [[bin]]
 name = "real_time"

--- a/bin/stems.rs
+++ b/bin/stems.rs
@@ -1,0 +1,37 @@
+use error::Error;
+use weresocool::{
+    generation::{filename_to_render, generate_waveforms, RenderReturn, RenderType},
+    renderable::nf_to_vec_renderable,
+    ui::get_args,
+    ui::{no_file_name, were_so_cool_logo},
+    write::write_composition_to_wav,
+};
+
+fn main() -> Result<(), Error> {
+    were_so_cool_logo();
+    let args = get_args();
+
+    let filename = args.value_of("filename");
+    match filename {
+        Some(_filename) => {}
+        _ => no_file_name(),
+    }
+
+    let render_return = filename_to_render(filename.unwrap(), RenderType::NfBasisAndTable)?;
+    let (nf, basis, table) = match render_return {
+        RenderReturn::NfBasisAndTable(nf, basis, table) => (nf, basis, table),
+        _ => panic!("huh"),
+    };
+    let renderables = nf_to_vec_renderable(&nf, &table, &basis);
+    let vec_wav = generate_waveforms(renderables, true);
+    for (i, w) in vec_wav.iter().enumerate() {
+        let f = format!("{}_{}.wav", &filename.clone().unwrap(), i);
+        let f = f.split("/").collect::<Vec<&str>>();
+        let f = f[f.len() - 1];
+        dbg!(&f);
+
+        write_composition_to_wav(w.clone(), &f);
+    }
+
+    Ok(())
+}

--- a/bin/stems.rs
+++ b/bin/stems.rs
@@ -30,7 +30,7 @@ fn main() -> Result<(), Error> {
         let f = f[f.len() - 1];
         dbg!(&f);
 
-        write_composition_to_wav(w.clone(), &f);
+        write_composition_to_wav(w.clone(), &f, false, false);
     }
 
     Ok(())

--- a/bin/stems.rs
+++ b/bin/stems.rs
@@ -28,7 +28,7 @@ fn main() -> Result<(), Error> {
         let f = format!("{}_{}.wav", &filename.clone().unwrap(), i);
         let f = f.split("/").collect::<Vec<&str>>();
         let f = f[f.len() - 1];
-        dbg!(&f);
+        println!("{}", &f);
 
         write_composition_to_wav(w.clone(), &f, false, false);
     }

--- a/src/generation/parsed_to_render.rs
+++ b/src/generation/parsed_to_render.rs
@@ -89,7 +89,7 @@ pub fn render(basis: &Basis, composition: &NormalForm, table: &OpOrNfTable) -> S
 
 pub fn to_wav(composition: StereoWaveform, filename: String) -> String {
     banner("Printing".to_string(), filename.clone());
-    write_composition_to_wav(composition, &filename);
+    write_composition_to_wav(composition, "composition.wav");
     printed("WAV".to_string());
     "composition.wav".to_string()
 }

--- a/src/generation/parsed_to_render.rs
+++ b/src/generation/parsed_to_render.rs
@@ -89,7 +89,7 @@ pub fn render(basis: &Basis, composition: &NormalForm, table: &OpOrNfTable) -> S
 
 pub fn to_wav(composition: StereoWaveform, filename: String) -> String {
     banner("Printing".to_string(), filename.clone());
-    write_composition_to_wav(composition, "composition.wav");
+    write_composition_to_wav(composition, "composition.wav", true, true);
     printed("WAV".to_string());
     "composition.wav".to_string()
 }

--- a/src/write.rs
+++ b/src/write.rs
@@ -57,7 +57,12 @@ fn wav_to_mp3_in_renders(filename: &str) {
     assert!(ecode.success());
 }
 
-pub fn write_composition_to_wav(composition: StereoWaveform, filename: &str) {
+pub fn write_composition_to_wav(
+    composition: StereoWaveform,
+    filename: &str,
+    mp3: bool,
+    normalize: bool,
+) {
     let spec = hound::WavSpec {
         channels: SETTINGS.channels as u16,
         sample_rate: SETTINGS.sample_rate as u32,
@@ -68,7 +73,9 @@ pub fn write_composition_to_wav(composition: StereoWaveform, filename: &str) {
     let mut buffer = vec![0.0; composition.r_buffer.len() * 2];
 
     write_output_buffer(&mut buffer, composition);
-    normalize_waveform(&mut buffer);
+    if normalize {
+        normalize_waveform(&mut buffer);
+    }
 
     let mut writer = hound::WavWriter::create(filename, spec).unwrap();
     for sample in buffer {
@@ -77,7 +84,9 @@ pub fn write_composition_to_wav(composition: StereoWaveform, filename: &str) {
             .expect("Error writing wave file.");
     }
 
-    wav_to_mp3_in_renders(filename);
+    if mp3 {
+        wav_to_mp3_in_renders(filename);
+    }
 }
 
 pub fn normalize_waveform(buffer: &mut Vec<f32>) {

--- a/src/write.rs
+++ b/src/write.rs
@@ -70,7 +70,7 @@ pub fn write_composition_to_wav(composition: StereoWaveform, filename: &str) {
     write_output_buffer(&mut buffer, composition);
     normalize_waveform(&mut buffer);
 
-    let mut writer = hound::WavWriter::create("composition.wav", spec).unwrap();
+    let mut writer = hound::WavWriter::create(filename, spec).unwrap();
     for sample in buffer {
         writer
             .write_sample(sample)

--- a/stems
+++ b/stems
@@ -2,4 +2,4 @@
 
 FILENAME=$1
 
-fd | entr -crs "echo | cargo run --release --bin stems $FILENAME"
+cargo run --release --bin stems $FILENAME

--- a/stems
+++ b/stems
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+
+FILENAME=$1
+
+fd | entr -crs "echo | cargo run --release --bin stems songs/$FILENAME.socool"

--- a/stems
+++ b/stems
@@ -2,4 +2,4 @@
 
 FILENAME=$1
 
-fd | entr -crs "echo | cargo run --release --bin stems songs/$FILENAME.socool"
+fd | entr -crs "echo | cargo run --release --bin stems $FILENAME"


### PR DESCRIPTION
Creates `bin/stems` and a shortcut with `./stems <filename>`. Probably could be better integrated, but this is the quickest path to the feature. 
<img width="234" alt="Screen Shot 2019-12-31 at 3 44 26 PM" src="https://user-images.githubusercontent.com/7309943/71633784-75603a80-2be4-11ea-8dd5-4edd4a64c999.png">
