### PR TITLE
Messing with your Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,24 @@
-package: 
+.PHONY: clippy dev format lint package run scratch test ts_test test_application test_rust test_rehash
+
+ifeq ($(OSTYPE),darwin)
+PACKAGE := application/release/mac/WereSoCool.app
+else
+PACKAGE := application/release/linux-unpacked/weresocool
+endif
+
+$(PACKAGE): application/node_modules
 	cd application && yarn package
 
-run:
-	./application/release/linux-unpacked/weresocool
+package: $(PACKAGE)
 
-run_osx:
-	open ./application/release/mac/WereSoCool.app
+run: $(PACKAGE)
+ifeq ($(OSTYPE),darwin)
+	open $(PACKAGE)
+else
+	$(PACKAGE)
+endif
 
-dev: 
+dev: application/node_modules
 	(cd application && yarn build-backend && yarn dev)
 
 test:
@@ -17,7 +28,7 @@ lint:
 	make clippy && \
 	make ts_test 
 
-ts_test:
+ts_test: application/node_modules
 	#!/usr/bin/env bash
 	set -euo pipefail
 
@@ -44,7 +55,7 @@ format_ci:
 clippy:
 	cargo clippy --all-targets -- -D warnings
 
-test_application: 
+test_application: application/node_modules
 	cd application && \
 	yarn package && \
 	yarn test
@@ -59,3 +70,5 @@ test_rehash:
 scratch:
 	cargo watch --exec "run --release --bin scratch"
 
+application/node_modules: application/yarn.lock
+	cd application && yarn install


### PR DESCRIPTION
The build failed for me at first, and it took me a bit to figure out that I needed to run `yarn install` and which directory to run it in. So I added a dependency to some of the Makefile targets so that they automatically install node modules whenever `application/yarn.lock` has changed. While I was in there I also made some other changes that I suggest for making the Makefile more idiomatic.