### PR TITLE
add libmp3lame-dev and rpm to list of packages to install in Ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ You'll need also need [portaudio](https://github.com/RustAudio/rust-portaudio) a
 `sudo pacman -S portaudio pkg-config lame`
 
 ##### Ubuntu:
-`sudo apt-get portaudio pkg-config lame`
+`sudo apt-get portaudio pkg-config lame libmp3lame-dev rpm`
 
 ### Build
 `make package`

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ You'll need also need [portaudio](https://github.com/RustAudio/rust-portaudio) a
 `sudo pacman -S portaudio pkg-config lame`
 
 ##### Ubuntu:
-`sudo apt-get portaudio pkg-config lame libmp3lame-dev rpm`
+`sudo apt-get portaudio pkg-config lame libmp3lame-dev rpm libasound2-dev`
 
 ### Build
 `make package`


### PR DESCRIPTION
In addition to the packages listed in the readme I needed to install `libmp3lame-dev` to get the project to build. And it's not strictly necessary for me, but I added `rpm` too because the package step fails if that is not present. I get an unpacked build artifact either way - but with `rpm` I don't have to see an error.

I'm running Debian Testing which usually has the same package names & per-project package requirements as Ubuntu.