### PR TITLE
make sure the server process gets killed successfully

### DIFF
--- a/application/app/main.dev.ts
+++ b/application/app/main.dev.ts
@@ -62,8 +62,11 @@ const createWindow = async () => {
   const port = await getPort({ port: 4588 });
   process.env.BACKEND_PORT = port.toString();
 
-  let server = child_process.spawn(`PORT=${port} ` + server_path, [], {
-    shell: true,
+  let server = child_process.spawn(server_path, [], {
+    env: {
+      PORT: port.toString(),
+      ...process.env
+    },
     stdio: 'inherit',
   });
 
@@ -99,7 +102,7 @@ const createWindow = async () => {
   mainWindow.on('closed', () => {
     mainWindow = null;
     server.kill('SIGKILL');
-    console.log('Server Stopped');
+    console.log('Server Storped');
     app.quit();
   });
 


### PR DESCRIPTION
child_process.spawn with option { shell: true } will use `/bin/sh` to
spawn a child process. Later sending signals (e.g. SIGKILL) to that
process will send the signal to the `/bin/sh` process. Which will
not reliably relay that signal to the real server process. This diff
fixes that by setting { shell: false }.

(The signal relaying works on some distros where `/bin/sh` is bash.
I'm not 100% sure why. I think because bash exec's into the given
process. It doesn't work on e.g. ubuntu, where `/bin/sh` is dash.)