### PR TITLE
List -> as_overlay

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ test_rust:
 	cargo run --release --bin snapshot
 
 test_rust_generated:
-	cargo test _generated
+	cargo test --release _generated
 
 test_rehash:
 	cargo run --release --bin snapshot -- --rehash

--- a/ast/src/lib.rs
+++ b/ast/src/lib.rs
@@ -11,7 +11,9 @@ pub use crate::{
         coefs::{Coef, Coefs},
         Axis, CoefState, GenOp, Generator,
     },
-    lists::{normalize_listop::join_list_nf, Index, IndexVector, Indices, ListOp, TermVector},
+    lists::{
+        normalize_listop::join_list_nf, Direction, Index, IndexVector, Indices, ListOp, TermVector,
+    },
     operations::{
         helpers::{handle_id_error, join_sequence},
         substitute::substitute_operations,

--- a/ast/src/lists/mod.rs
+++ b/ast/src/lists/mod.rs
@@ -7,10 +7,10 @@ use crate::{GenOp, Term};
 #[derive(Clone, PartialEq, Debug, Hash)]
 pub enum ListOp {
     Const {
-        value: Vec<Term>,
+        terms: Vec<Term>,
     },
     Named {
-        value: String,
+        name: String,
     },
     ListOpIndexed {
         list_op: Box<ListOp>,
@@ -18,10 +18,10 @@ pub enum ListOp {
         direction: Direction,
     },
     GenOp {
-        value: GenOp,
+        gen: GenOp,
     },
     Concat {
-        value: Vec<ListOp>,
+        listops: Vec<ListOp>,
     },
 }
 

--- a/ast/src/lists/mod.rs
+++ b/ast/src/lists/mod.rs
@@ -6,14 +6,22 @@ use crate::{GenOp, Term};
 
 #[derive(Clone, PartialEq, Debug, Hash)]
 pub enum ListOp {
-    Const(Vec<Term>),
-    Named(String),
+    Const {
+        value: Vec<Term>,
+    },
+    Named {
+        value: String,
+    },
     ListOpIndexed {
         list_op: Box<ListOp>,
         indices: Indices,
     },
-    GenOp(GenOp),
-    Concat(Vec<ListOp>),
+    GenOp {
+        value: GenOp,
+    },
+    Concat {
+        value: Vec<ListOp>,
+    },
 }
 
 #[derive(Clone, PartialEq, Debug, Hash)]

--- a/ast/src/lists/mod.rs
+++ b/ast/src/lists/mod.rs
@@ -15,6 +15,7 @@ pub enum ListOp {
     ListOpIndexed {
         list_op: Box<ListOp>,
         indices: Indices,
+        direction: Direction,
     },
     GenOp {
         value: GenOp,
@@ -22,6 +23,12 @@ pub enum ListOp {
     Concat {
         value: Vec<ListOp>,
     },
+}
+
+#[derive(Clone, PartialEq, Debug, Hash)]
+pub enum Direction {
+    Overlay,
+    Sequence,
 }
 
 #[derive(Clone, PartialEq, Debug, Hash)]

--- a/ast/src/lists/normalize_listop.rs
+++ b/ast/src/lists/normalize_listop.rs
@@ -1,5 +1,6 @@
 use crate::{
-    handle_id_error, join_sequence, GetLengthRatio, ListOp, NormalForm, Normalize, Term, TermVector,
+    handle_id_error, join_sequence, GetLengthRatio, ListOp, NormalForm, Normalize, Op, Term,
+    TermVector,
 };
 use num_rational::Rational64;
 use scop::Defs;
@@ -169,7 +170,14 @@ impl Normalize<Term> for ListOp {
                     *input = join_list_nf(self.to_list_nf(input, defs)?);
                 }
                 crate::Direction::Overlay => {
-                    unimplemented!()
+                    Op::Overlay {
+                        operations: self
+                            .to_list_nf(input, defs)?
+                            .iter()
+                            .map(|nf| Term::Nf(nf.to_owned()))
+                            .collect(),
+                    }
+                    .apply_to_normal_form(input, defs)?;
                 }
             },
             _ => *input = join_list_nf(self.to_list_nf(input, defs)?),

--- a/ast/src/lists/normalize_listop.rs
+++ b/ast/src/lists/normalize_listop.rs
@@ -86,7 +86,6 @@ impl GetLengthRatio<Term> for ListOp {
                 }
             }
             ListOp::ListOpIndexed { .. } => {
-                unimplemented!();
                 let mut nf = NormalForm::init();
                 self.apply_to_normal_form(&mut nf, defs)?;
                 nf.get_length_ratio(normal_form, defs)

--- a/ast/src/lists/normalize_listop.rs
+++ b/ast/src/lists/normalize_listop.rs
@@ -9,15 +9,15 @@ use weresocool_error::Error;
 impl ListOp {
     pub fn term_vectors(&self, defs: &mut Defs<Term>) -> Result<Vec<TermVector>, Error> {
         match self {
-            ListOp::Const { value } => Ok(value
+            ListOp::Const { terms } => Ok(terms
                 .iter()
                 .map(|term| TermVector {
                     term: term.to_owned(),
                     index_terms: vec![],
                 })
                 .collect()),
-            ListOp::Named { value } => {
-                let term = handle_id_error(value.to_string(), defs)?;
+            ListOp::Named { name } => {
+                let term = handle_id_error(name.to_string(), defs)?;
                 match term {
                     Term::Lop(lop) => lop.term_vectors(defs),
                     _ => Err(Error::with_msg("List.term_vectors() called on non-list")),
@@ -40,16 +40,16 @@ impl ListOp {
                     })
                     .collect())
             }
-            ListOp::Concat { value } => {
+            ListOp::Concat { listops } => {
                 let mut result = vec![];
-                for list in value {
+                for list in listops {
                     result.extend(list.term_vectors(defs)?)
                 }
 
                 Ok(result)
             }
-            ListOp::GenOp { value } => {
-                let result = value
+            ListOp::GenOp { gen } => {
+                let result = gen
                     .to_owned()
                     .term_vectors_from_genop(None, defs)?
                     .iter()
@@ -71,13 +71,13 @@ impl GetLengthRatio<Term> for ListOp {
         defs: &mut Defs<Term>,
     ) -> Result<Rational64, Error> {
         match self {
-            ListOp::Const { value } => value
+            ListOp::Const { terms } => terms
                 .iter()
                 .try_fold(Rational64::from_integer(0), |acc, term| {
                     Ok(acc + term.get_length_ratio(normal_form, defs)?)
                 }),
-            ListOp::Named { value } => {
-                let term = handle_id_error(value, defs)?;
+            ListOp::Named { name } => {
+                let term = handle_id_error(name, defs)?;
                 match term {
                     Term::Lop(lop) => lop.get_length_ratio(normal_form, defs),
                     _ => Err(Error::with_msg(
@@ -90,12 +90,12 @@ impl GetLengthRatio<Term> for ListOp {
                 self.apply_to_normal_form(&mut nf, defs)?;
                 nf.get_length_ratio(normal_form, defs)
             }
-            ListOp::Concat { value } => value
+            ListOp::Concat { listops } => listops
                 .iter()
                 .try_fold(Rational64::from_integer(0), |acc, term| {
                     Ok(acc + term.get_length_ratio(normal_form, defs)?)
                 }),
-            ListOp::GenOp { value } => value.get_length_ratio(normal_form, defs),
+            ListOp::GenOp { gen } => gen.get_length_ratio(normal_form, defs),
         }
     }
 }
@@ -107,7 +107,7 @@ impl ListOp {
         defs: &mut Defs<Term>,
     ) -> Result<Vec<NormalForm>, Error> {
         match self {
-            ListOp::Const { value } => value
+            ListOp::Const { terms } => terms
                 .iter()
                 .map(|op| {
                     let mut input_clone = input.clone();
@@ -116,8 +116,8 @@ impl ListOp {
                 })
                 .collect::<Result<Vec<NormalForm>, Error>>(),
 
-            ListOp::Named { value } => {
-                let term = handle_id_error(value, defs)?;
+            ListOp::Named { name } => {
+                let term = handle_id_error(name, defs)?;
                 match term {
                     Term::Lop(lop) => lop.to_list_nf(input, defs),
 
@@ -144,7 +144,7 @@ impl ListOp {
                     Ok(nf)
                 })
                 .collect::<Result<Vec<NormalForm>, Error>>(),
-            ListOp::Concat { value } => value
+            ListOp::Concat { listops } => listops
                 .iter()
                 .map(|list| {
                     let mut nf = input.clone();
@@ -152,7 +152,7 @@ impl ListOp {
                     Ok(nf)
                 })
                 .collect(),
-            ListOp::GenOp { value, .. } => value.to_owned().generate_from_genop(input, None, defs),
+            ListOp::GenOp { gen } => gen.to_owned().generate_from_genop(input, None, defs),
         }
     }
 }

--- a/ast/src/lists/normalize_listop.rs
+++ b/ast/src/lists/normalize_listop.rs
@@ -165,9 +165,6 @@ impl Normalize<Term> for ListOp {
     ) -> Result<(), Error> {
         match self {
             ListOp::ListOpIndexed { direction, .. } => match direction {
-                crate::Direction::Sequence => {
-                    *input = join_list_nf(self.to_list_nf(input, defs)?);
-                }
                 crate::Direction::Overlay => {
                     Op::Overlay {
                         operations: self
@@ -177,6 +174,9 @@ impl Normalize<Term> for ListOp {
                             .collect(),
                     }
                     .apply_to_normal_form(input, defs)?;
+                }
+                _ => {
+                    *input = join_list_nf(self.to_list_nf(input, defs)?);
                 }
             },
             _ => *input = join_list_nf(self.to_list_nf(input, defs)?),

--- a/ast/src/lists/substitute_list.rs
+++ b/ast/src/lists/substitute_list.rs
@@ -11,21 +11,20 @@ impl Substitute<Term> for ListOp {
         defs: &mut Defs<Term>,
     ) -> Result<Term, Error> {
         match self {
-            ListOp::Const(terms) => Ok(Term::Lop(ListOp::Const(substitute_operations(
-                terms.to_vec(),
-                normal_form,
-                defs,
-            )?))),
-            ListOp::Named(name) => {
-                let term = handle_id_error(name, defs)?;
+            ListOp::Const { value: terms } => Ok(Term::Lop(ListOp::Const {
+                value: substitute_operations(terms.to_vec(), normal_form, defs)?,
+            })),
+            ListOp::Named { value } => {
+                let term = handle_id_error(value, defs)?;
 
                 match term {
                     Term::Lop(lop) => lop.substitute(normal_form, defs),
                     _ => Err(Error::with_msg("List.substitute() on called non-list")),
                 }
             }
-            ListOp::ListOpIndexed { .. } => Ok(Term::Lop(ListOp::Const(
-                self.term_vectors(defs)?
+            ListOp::ListOpIndexed { .. } => Ok(Term::Lop(ListOp::Const {
+                value: self
+                    .term_vectors(defs)?
                     .iter_mut()
                     .map(|term_vector| {
                         let mut nf = normal_form.clone();
@@ -38,16 +37,16 @@ impl Substitute<Term> for ListOp {
                         Ok(Term::Nf(nf))
                     })
                     .collect::<Result<Vec<Term>, Error>>()?,
-            ))),
-            ListOp::Concat(lists) => {
+            })),
+            ListOp::Concat { value } => {
                 let mut result = vec![];
-                for list in lists {
+                for list in value {
                     result.push(list.substitute(normal_form, defs)?)
                 }
 
-                Ok(Term::Lop(ListOp::Const(result)))
+                Ok(Term::Lop(ListOp::Const { value: result }))
             }
-            ListOp::GenOp(gen) => gen.substitute(normal_form, defs),
+            ListOp::GenOp { value } => value.substitute(normal_form, defs),
         }
     }
 }

--- a/ast/src/lists/substitute_list.rs
+++ b/ast/src/lists/substitute_list.rs
@@ -11,11 +11,11 @@ impl Substitute<Term> for ListOp {
         defs: &mut Defs<Term>,
     ) -> Result<Term, Error> {
         match self {
-            ListOp::Const { value: terms } => Ok(Term::Lop(ListOp::Const {
-                value: substitute_operations(terms.to_vec(), normal_form, defs)?,
+            ListOp::Const { terms } => Ok(Term::Lop(ListOp::Const {
+                terms: substitute_operations(terms.to_vec(), normal_form, defs)?,
             })),
-            ListOp::Named { value } => {
-                let term = handle_id_error(value, defs)?;
+            ListOp::Named { name } => {
+                let term = handle_id_error(name, defs)?;
 
                 match term {
                     Term::Lop(lop) => lop.substitute(normal_form, defs),
@@ -23,7 +23,7 @@ impl Substitute<Term> for ListOp {
                 }
             }
             ListOp::ListOpIndexed { .. } => Ok(Term::Lop(ListOp::Const {
-                value: self
+                terms: self
                     .term_vectors(defs)?
                     .iter_mut()
                     .map(|term_vector| {
@@ -38,15 +38,15 @@ impl Substitute<Term> for ListOp {
                     })
                     .collect::<Result<Vec<Term>, Error>>()?,
             })),
-            ListOp::Concat { value } => {
+            ListOp::Concat { listops } => {
                 let mut result = vec![];
-                for list in value {
+                for list in listops {
                     result.push(list.substitute(normal_form, defs)?)
                 }
 
-                Ok(Term::Lop(ListOp::Const { value: result }))
+                Ok(Term::Lop(ListOp::Const { terms: result }))
             }
-            ListOp::GenOp { value, .. } => value.substitute(normal_form, defs),
+            ListOp::GenOp { gen, .. } => gen.substitute(normal_form, defs),
         }
     }
 }

--- a/ast/src/lists/substitute_list.rs
+++ b/ast/src/lists/substitute_list.rs
@@ -46,7 +46,7 @@ impl Substitute<Term> for ListOp {
 
                 Ok(Term::Lop(ListOp::Const { value: result }))
             }
-            ListOp::GenOp { value } => value.substitute(normal_form, defs),
+            ListOp::GenOp { value, .. } => value.substitute(normal_form, defs),
         }
     }
 }

--- a/mocks/list/as_overlay.socool
+++ b/mocks/list/as_overlay.socool
@@ -1,0 +1,10 @@
+{ f: 220, l: 1, g: 1, p: 0 } 
+
+main = {
+    &[Fm 1, Fm 9/8] % [:]
+}
+
+expect = {
+    Overlay [Fm 1, Fm 9/8]
+}
+

--- a/mocks/list/as_overlay_fit_length.socool
+++ b/mocks/list/as_overlay_fit_length.socool
@@ -5,10 +5,16 @@ thing = {
 }
 
 main = {
-     Fm 2 | FitLength thing
+    Overlay [
+        Fm 2 | FitLength thing,
+        thing | FitLength Lm 6,
+    ]
 }
 
 expect = {
-    Fm 2 | Lm 3
+    Overlay [
+        Fm 2 | Lm 3,
+        thing | Lm 2,
+    ]
 }
 

--- a/mocks/list/as_overlay_fit_length.socool
+++ b/mocks/list/as_overlay_fit_length.socool
@@ -1,0 +1,14 @@
+{ f: 220, l: 1, g: 1, p: 0 } 
+
+thing = {
+    &[Fm 1, Fm 9/8 | Lm 3] % [:]
+}
+
+main = {
+     Fm 2 | FitLength thing
+}
+
+expect = {
+    Fm 2 | Lm 3
+}
+

--- a/parser/src/socool.lalrpop
+++ b/parser/src/socool.lalrpop
@@ -164,7 +164,7 @@ CoefTimes: usize = {
 
 
 List: ListOp = {
-  <lists: ListConcat> => ListOp::Concat(lists),
+  <lists: ListConcat> => ListOp::Concat{ value: lists },
   <list: ListIndexed> => list,
 
 }
@@ -183,18 +183,18 @@ ListIndexed: ListOp = {
 
 ListBase: ListOp = {
   r"(List|&)" "[" <operations: Operations> "]" => {
-    ListOp::Const(operations)
+    ListOp::Const{ value: operations }
   },
 
   r"(List|&)" <name: Name> => {
-    ListOp::Named(name)
+    ListOp::Named { value: name }
   },
 
   "ET" "(" <n: Int> ")" => {
-    ListOp::Const(et(n))
+    ListOp::Const{ value: et(n) }
   },
 
-  r"(List|&)" <gen: Generator> => ListOp::GenOp(gen)
+  r"(List|&)" <gen: Generator> => ListOp::GenOp { value: gen }
 }
 
 Indices: Indices = {

--- a/parser/src/socool.lalrpop
+++ b/parser/src/socool.lalrpop
@@ -165,7 +165,7 @@ CoefTimes: usize = {
 
 
 List: ListOp = {
-  <lists: ListConcat> => ListOp::Concat{ value: lists },
+  <listops: ListConcat> => ListOp::Concat{ listops },
   <list: ListIndexed> => list,
 
 }
@@ -187,19 +187,19 @@ ListIndexed: ListOp = {
 }
 
 ListBase: ListOp = {
-  r"(List|&)" "[" <operations: Operations> "]" => {
-    ListOp::Const{ value: operations }
+  r"(List|&)" "[" <terms: Operations> "]" => {
+    ListOp::Const{ terms }
   },
 
   r"(List|&)" <name: Name> => {
-    ListOp::Named { value: name }
+    ListOp::Named { name }
   },
 
   "ET" "(" <n: Int> ")" => {
-    ListOp::Const{ value: et(n) }
+    ListOp::Const{ terms: et(n) }
   },
 
-  r"(List|&)" <gen: Generator> => ListOp::GenOp { value: gen }
+  r"(List|&)" <gen: Generator> => ListOp::GenOp { gen }
 }
 
 Indices: Indices = {

--- a/parser/src/socool.lalrpop
+++ b/parser/src/socool.lalrpop
@@ -8,6 +8,7 @@ use weresocool_ast::{
         ASR,
         FunDef,
         ListOp,
+        Direction,
         CoefState,
         Coefs,
         Coef,
@@ -173,7 +174,11 @@ ListConcat = Concat<ListIndexed>;
 
 ListIndexed: ListOp = {
   <listop: ListIndexed> "@" "[" <indices: Indices> "]" => {
-    ListOp::ListOpIndexed { list_op: Box::new(listop), indices}
+    ListOp::ListOpIndexed { list_op: Box::new(listop), indices, direction: Direction::Sequence}
+  },
+
+  <listop: ListIndexed> "%" "[" <indices: Indices> "]" => {
+    ListOp::ListOpIndexed { list_op: Box::new(listop), indices, direction: Direction::Overlay}
   },
 
    "<" <list: List> ">" => list,


### PR DESCRIPTION
List as an Overlay rather than a Sequence. I think this would be a fun way to practice composing in ET(31), etc.

```
{ f: 220, l: 1, g: 1, p: 0 } 

main = {
    &[Fm 1, Fm 9/8] % [:]
}

expect = {
    Overlay [Fm 1, Fm 9/8]
}
```