### PR TITLE
Fix Just issue on CI

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -22,10 +22,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: echo "GH_TOKEN=${GITHUB_TOKEN}" >> $GITHUB_ENV
 
-      - uses: extractions/setup-just@v1
-
       - name: install macos dependancies
-        run: brew install portaudio pkg-config lame libvorbis
+        run: brew install portaudio pkg-config lame libvorbis just
       - name: Installing Rust toolchain
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/cool_tests.yml
+++ b/.github/workflows/cool_tests.yml
@@ -16,8 +16,6 @@ jobs:
       run: | 
         sudo apt install -y libasound2-dev portaudio19-dev libportaudio2 libportaudiocpp0 pkg-config lame libmp3lame-dev vorbis-tools lld just
     - uses: Swatinem/rust-cache@v2
-      with:
-        shared-key: 'weresocool'
     - uses: actions/checkout@v2
 
     - uses: actions-rs/toolchain@v1
@@ -46,8 +44,6 @@ jobs:
         sudo apt install -y libasound2-dev portaudio19-dev libportaudio2 libportaudiocpp0 pkg-config lame libmp3lame-dev vorbis-tools lld pulseaudio just
     - uses: actions/checkout@v2
     - uses: Swatinem/rust-cache@v2
-      with:
-        shared-key: 'weresocool'
     - uses: actions-rs/toolchain@v1
       with:
           toolchain: stable
@@ -63,8 +59,6 @@ jobs:
         run: brew install portaudio pkg-config lame libvorbis just
       - uses: actions/checkout@v2
       - uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: 'weresocool'
       - uses: actions-rs/toolchain@v1
         with:
             toolchain: stable

--- a/.github/workflows/cool_tests.yml
+++ b/.github/workflows/cool_tests.yml
@@ -7,13 +7,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: extractions/setup-just@v1
-      with: 
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
+    - name: setup pre-built mpr
+      run: | 
+        curl -q 'https://proget.makedeb.org/debian-feeds/prebuilt-mpr.pub' | gpg --dearmor | sudo tee /usr/share/keyrings/prebuilt-mpr-archive-keyring.gpg 1> /dev/null
+        echo "deb [signed-by=/usr/share/keyrings/prebuilt-mpr-archive-keyring.gpg] https://proget.makedeb.org prebuilt-mpr $(lsb_release -cs)" | sudo tee /etc/apt/sources.list.d/prebuilt-mpr.list
+        sudo apt update
     - name: install dependancies
       run: | 
-        sudo apt update
-        sudo apt install -y libasound2-dev portaudio19-dev libportaudio2 libportaudiocpp0 pkg-config lame libmp3lame-dev vorbis-tools lld
+        sudo apt install -y libasound2-dev portaudio19-dev libportaudio2 libportaudiocpp0 pkg-config lame libmp3lame-dev vorbis-tools lld just
     - uses: actions/checkout@v2
     - uses: actions-rs/toolchain@v1
       with:
@@ -29,13 +30,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: setup pre-built mpr
+      run: | 
+        curl -q 'https://proget.makedeb.org/debian-feeds/prebuilt-mpr.pub' | gpg --dearmor | sudo tee /usr/share/keyrings/prebuilt-mpr-archive-keyring.gpg 1> /dev/null
+        echo "deb [signed-by=/usr/share/keyrings/prebuilt-mpr-archive-keyring.gpg] https://proget.makedeb.org prebuilt-mpr $(lsb_release -cs)" | sudo tee /etc/apt/sources.list.d/prebuilt-mpr.list
+        sudo apt update
     - name: setup dummy soundcard
       run: sudo echo "pcm.!default { type plug slave.pcm 'null' }" > $HOME/.asoundrc
-    - uses: extractions/setup-just@v1
     - name: install dependancies
       run: | 
-        sudo apt update
-        sudo apt install -y libasound2-dev portaudio19-dev libportaudio2 libportaudiocpp0 pkg-config lame libmp3lame-dev vorbis-tools lld pulseaudio
+        sudo apt install -y libasound2-dev portaudio19-dev libportaudio2 libportaudiocpp0 pkg-config lame libmp3lame-dev vorbis-tools lld pulseaudio just
     - uses: actions/checkout@v2
     - uses: actions-rs/toolchain@v1
       with:
@@ -48,9 +52,8 @@ jobs:
       runs-on: macos-latest 
 
       steps:
-      - uses: extractions/setup-just@v1
       - name: install dependancies
-        run: brew install portaudio pkg-config lame libvorbis
+        run: brew install portaudio pkg-config lame libvorbis just
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/cool_tests.yml
+++ b/.github/workflows/cool_tests.yml
@@ -15,7 +15,11 @@ jobs:
     - name: install dependancies
       run: | 
         sudo apt install -y libasound2-dev portaudio19-dev libportaudio2 libportaudiocpp0 pkg-config lame libmp3lame-dev vorbis-tools lld just
+    - uses: Swatinem/rust-cache@v2
+      with:
+        shared-key: 'weresocool'
     - uses: actions/checkout@v2
+
     - uses: actions-rs/toolchain@v1
       with:
           toolchain: stable
@@ -41,6 +45,9 @@ jobs:
       run: | 
         sudo apt install -y libasound2-dev portaudio19-dev libportaudio2 libportaudiocpp0 pkg-config lame libmp3lame-dev vorbis-tools lld pulseaudio just
     - uses: actions/checkout@v2
+    - uses: Swatinem/rust-cache@v2
+      with:
+        shared-key: 'weresocool'
     - uses: actions-rs/toolchain@v1
       with:
           toolchain: stable
@@ -55,6 +62,9 @@ jobs:
       - name: install dependancies
         run: brew install portaudio pkg-config lame libvorbis just
       - uses: actions/checkout@v2
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: 'weresocool'
       - uses: actions-rs/toolchain@v1
         with:
             toolchain: stable

--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ Available on the AUR [here](https://aur.archlinux.org/packages/weresocool).
 
 ### Cargo:
 
-WereSoCool can be installed via on any unix system via cargo
+WereSoCool can be installed on any unix system via cargo. You'll also need to install the system dependancies listed
+in the development section. 
+are 
 
 `cargo install weresocool`
 


### PR DESCRIPTION
extractions/setup-just@v1 was often throwing the error `API rate limit exceeded for 199.7.166.17. (But here's the good news: Authenticated requests get a higher rate limit` on CI. 

Updated to install just along with the other system deps. 